### PR TITLE
Add GetResponsible to DomainsService

### DIFF
--- a/domains.go
+++ b/domains.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"net/url"
 	"time"
 )
 
@@ -67,6 +68,30 @@ func (s *DomainsService) Create(ctx context.Context, domainName string) (*Domain
 // GetAll listing domains.
 // https://desec.readthedocs.io/en/latest/dns/domains.html#listing-domains
 func (s *DomainsService) GetAll(ctx context.Context) ([]Domain, error) {
+	return s.getAll(ctx, nil)
+}
+
+// GetResponsible returns the responsible domain for a given DNS query name.
+// https://desec.readthedocs.io/en/latest/dns/domains.html#identifying-the-responsible-domain-for-a-dns-name
+func (s *DomainsService) GetResponsible(ctx context.Context, domainName string) (*Domain, error) {
+	queryValues := url.Values{}
+	queryValues.Set("owns_qname", domainName)
+
+	domains, err := s.getAll(ctx, queryValues)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(domains) == 0 {
+		return nil, &NotFoundError{Detail: "no responsible domain found"}
+	}
+
+	return &domains[0], nil
+}
+
+// getAll listing domains.
+// https://desec.readthedocs.io/en/latest/dns/domains.html#listing-domains
+func (s *DomainsService) getAll(ctx context.Context, query url.Values) ([]Domain, error) {
 	endpoint, err := s.client.createEndpoint("domains")
 	if err != nil {
 		return nil, fmt.Errorf("failed to create endpoint: %w", err)
@@ -75,6 +100,10 @@ func (s *DomainsService) GetAll(ctx context.Context) ([]Domain, error) {
 	req, err := s.client.newRequest(ctx, http.MethodGet, endpoint, nil)
 	if err != nil {
 		return nil, err
+	}
+
+	if len(query) > 0 {
+		req.URL.RawQuery = query.Encode()
 	}
 
 	resp, err := s.client.httpClient.Do(req)
@@ -95,45 +124,6 @@ func (s *DomainsService) GetAll(ctx context.Context) ([]Domain, error) {
 	}
 
 	return domains, nil
-}
-
-// GetResponsible returns the responsible domain for a given DNS query name.
-// https://desec.readthedocs.io/en/latest/dns/domains.html#identifying-the-responsible-domain-for-a-dns-name
-func (s *DomainsService) GetResponsible(ctx context.Context, domainName string) (*Domain, error) {
-	endpoint, err := s.client.createEndpoint("domains")
-	if err != nil {
-		return nil, fmt.Errorf("failed to create endpoint: %w", err)
-	}
-
-	req, err := s.client.newRequest(ctx, http.MethodGet, endpoint, nil)
-	if err != nil {
-		return nil, err
-	}
-	queryValues := req.URL.Query()
-	queryValues.Add("owns_qname", domainName)
-	req.URL.RawQuery = queryValues.Encode()
-
-	resp, err := s.client.httpClient.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("failed to call API: %w", err)
-	}
-
-	defer func() { _ = resp.Body.Close() }()
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, handleError(resp)
-	}
-
-	var domains []Domain
-	if err = handleResponse(resp, &domains); err != nil {
-		return nil, err
-	}
-
-	if len(domains) == 0 {
-		return nil, NotFoundError{Detail: "No responsible domain found"}
-	}
-
-	return &domains[0], nil
 }
 
 // Get retrieving a specific domain.

--- a/fixtures/domains_getresponsible.json
+++ b/fixtures/domains_getresponsible.json
@@ -1,0 +1,8 @@
+[
+  {
+    "created": "2022-11-12T18:01:35.454616Z",
+    "published": "2022-11-12T18:03:19.516440Z",
+    "name": "dev.example.org",
+    "minimum_ttl": 3600
+  }
+]


### PR DESCRIPTION
This allows identifying the responsible domain for a DNS name that's available as documented: https://desec.readthedocs.io/en/latest/dns/domains.html#identifying-the-responsible-domain-for-a-dns-name.

This replaces #7.