### PR TITLE
feat: add bulk methods

### DIFF
--- a/desec.go
+++ b/desec.go
@@ -131,6 +131,10 @@ func handleResponse(resp *http.Response, respData interface{}) error {
 		}
 	}
 
+	if len(body) == 0 {
+		return nil
+	}
+
 	err = json.Unmarshal(body, respData)
 	if err != nil {
 		return fmt.Errorf("failed to umarshal response body: %w", err)

--- a/fixtures/records_create.json
+++ b/fixtures/records_create.json
@@ -1,11 +1,13 @@
-{
-  "created": "2020-05-06T11:46:07.641885Z",
-  "domain": "example.dedyn.io",
-  "subname": "_acme-challenge",
-  "name": "_acme-challenge.example.dedyn.io.",
-  "records": [
-    "\"txt\""
-  ],
-  "ttl": 300,
-  "type": "TXT"
-}
+[
+  {
+    "created": "2020-05-06T11:46:07.641885Z",
+    "domain": "example.dedyn.io",
+    "subname": "_acme-challenge",
+    "name": "_acme-challenge.example.dedyn.io.",
+    "records": [
+      "\"txt\""
+    ],
+    "ttl": 300,
+    "type": "TXT"
+  }
+]

--- a/fixtures/records_create.json
+++ b/fixtures/records_create.json
@@ -1,13 +1,11 @@
-[
-  {
-    "created": "2020-05-06T11:46:07.641885Z",
-    "domain": "example.dedyn.io",
-    "subname": "_acme-challenge",
-    "name": "_acme-challenge.example.dedyn.io.",
-    "records": [
-      "\"txt\""
-    ],
-    "ttl": 300,
-    "type": "TXT"
-  }
-]
+{
+  "created": "2020-05-06T11:46:07.641885Z",
+  "domain": "example.dedyn.io",
+  "subname": "_acme-challenge",
+  "name": "_acme-challenge.example.dedyn.io.",
+  "records": [
+    "\"txt\""
+  ],
+  "ttl": 300,
+  "type": "TXT"
+}

--- a/fixtures/records_create_bulk.json
+++ b/fixtures/records_create_bulk.json
@@ -1,0 +1,13 @@
+[
+  {
+    "created": "2020-05-06T11:46:07.641885Z",
+    "domain": "example.dedyn.io",
+    "subname": "_acme-challenge",
+    "name": "_acme-challenge.example.dedyn.io.",
+    "records": [
+      "\"txt\""
+    ],
+    "ttl": 300,
+    "type": "TXT"
+  }
+]

--- a/fixtures/records_update_bulk.json
+++ b/fixtures/records_update_bulk.json
@@ -1,0 +1,13 @@
+[
+  {
+    "created": "2020-05-06T11:46:07.641885Z",
+    "domain": "example.dedyn.io",
+    "subname": "_acme-challenge",
+    "name": "_acme-challenge.example.dedyn.io.",
+    "records": [
+      "\"updated\""
+    ],
+    "ttl": 300,
+    "type": "TXT"
+  }
+]

--- a/records.go
+++ b/records.go
@@ -112,39 +112,6 @@ func (s *RecordsService) Create(ctx context.Context, rrSet RRSet) (*RRSet, error
 	return &newRRSet, nil
 }
 
-// BulkCreate creates new RRSets in bulk.
-// https://desec.readthedocs.io/en/latest/dns/rrsets.html#bulk-creation-of-rrsets
-func (s *RecordsService) BulkCreate(ctx context.Context, domainName string, rrSets []RRSet) ([]RRSet, error) {
-	endpoint, err := s.client.createEndpoint("domains", domainName, "rrsets")
-	if err != nil {
-		return nil, fmt.Errorf("failed to create endpoint: %w", err)
-	}
-
-	req, err := s.client.newRequest(ctx, http.MethodPost, endpoint, rrSets)
-	if err != nil {
-		return nil, err
-	}
-
-	resp, err := s.client.httpClient.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("failed to call API: %w", err)
-	}
-
-	defer func() { _ = resp.Body.Close() }()
-
-	if resp.StatusCode != http.StatusCreated {
-		return nil, handleError(resp)
-	}
-
-	var newRRSets []RRSet
-	err = handleResponse(resp, &newRRSets)
-	if err != nil {
-		return nil, err
-	}
-
-	return newRRSets, nil
-}
-
 /*
 	Domains + subname + type
 */
@@ -228,39 +195,6 @@ func (s *RecordsService) Update(ctx context.Context, domainName, subName, record
 	return &updatedRRSet, nil
 }
 
-// BulkUpdate updates RRSets in bulk (PUT).
-// https://desec.readthedocs.io/en/latest/dns/rrsets.html#bulk-modification-of-rrsets
-func (s *RecordsService) BulkUpdate(ctx context.Context, domainName string, rrSets []RRSet) ([]RRSet, error) {
-	endpoint, err := s.client.createEndpoint("domains", domainName, "rrsets")
-	if err != nil {
-		return nil, fmt.Errorf("failed to create endpoint: %w", err)
-	}
-
-	req, err := s.client.newRequest(ctx, http.MethodPut, endpoint, rrSets)
-	if err != nil {
-		return nil, err
-	}
-
-	resp, err := s.client.httpClient.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("failed to call API: %w", err)
-	}
-
-	defer func() { _ = resp.Body.Close() }()
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, handleError(resp)
-	}
-
-	var updatedRRSets []RRSet
-	err = handleResponse(resp, &updatedRRSets)
-	if err != nil {
-		return nil, err
-	}
-
-	return updatedRRSets, nil
-}
-
 // Replace replaces a RRSet (PUT).
 // https://desec.readthedocs.io/en/latest/dns/rrsets.html#modifying-an-rrset
 func (s *RecordsService) Replace(ctx context.Context, domainName, subName, recordType string, rrSet RRSet) (*RRSet, error) {
@@ -332,6 +266,76 @@ func (s *RecordsService) Delete(ctx context.Context, domainName, subName, record
 	}
 
 	return nil
+}
+
+/*
+	Bulk operation
+*/
+
+// BulkCreate creates new RRSets in bulk.
+// https://desec.readthedocs.io/en/latest/dns/rrsets.html#bulk-creation-of-rrsets
+func (s *RecordsService) BulkCreate(ctx context.Context, domainName string, rrSets []RRSet) ([]RRSet, error) {
+	endpoint, err := s.client.createEndpoint("domains", domainName, "rrsets")
+	if err != nil {
+		return nil, fmt.Errorf("failed to create endpoint: %w", err)
+	}
+
+	req, err := s.client.newRequest(ctx, http.MethodPost, endpoint, rrSets)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := s.client.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to call API: %w", err)
+	}
+
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusCreated {
+		return nil, handleError(resp)
+	}
+
+	var newRRSets []RRSet
+	err = handleResponse(resp, &newRRSets)
+	if err != nil {
+		return nil, err
+	}
+
+	return newRRSets, nil
+}
+
+// BulkUpdate updates RRSets in bulk (PUT).
+// https://desec.readthedocs.io/en/latest/dns/rrsets.html#bulk-modification-of-rrsets
+func (s *RecordsService) BulkUpdate(ctx context.Context, domainName string, rrSets []RRSet) ([]RRSet, error) {
+	endpoint, err := s.client.createEndpoint("domains", domainName, "rrsets")
+	if err != nil {
+		return nil, fmt.Errorf("failed to create endpoint: %w", err)
+	}
+
+	req, err := s.client.newRequest(ctx, http.MethodPut, endpoint, rrSets)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := s.client.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to call API: %w", err)
+	}
+
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, handleError(resp)
+	}
+
+	var updatedRRSets []RRSet
+	err = handleResponse(resp, &updatedRRSets)
+	if err != nil {
+		return nil, err
+	}
+
+	return updatedRRSets, nil
 }
 
 // BulkDelete deletes RRSets in bulk (PATCH).

--- a/records.go
+++ b/records.go
@@ -269,14 +269,17 @@ func (s *RecordsService) Delete(ctx context.Context, domainName, subName, record
 }
 
 /*
-	Bulk operation
+	Bulk operations
 */
 
+// UpdateMode the mode used to bulk update operations.
 type UpdateMode string
 
 const (
-	FullResourceUpdateMode            = http.MethodPut
-	OnlyFields             UpdateMode = http.MethodPatch
+	// FullResourceUpdateMode the full resource must be specified.
+	FullResourceUpdateMode = http.MethodPut
+	// OnlyFields only fields you would like to modify need to be provided.
+	OnlyFields UpdateMode = http.MethodPatch
 )
 
 // BulkCreate creates new RRSets in bulk.

--- a/records.go
+++ b/records.go
@@ -240,16 +240,18 @@ func (s *RecordsService) Replace(ctx context.Context, domainName, subName, recor
 // Delete deletes a RRset.
 // https://desec.readthedocs.io/en/latest/dns/rrsets.html#deleting-an-rrset
 func (s *RecordsService) Delete(ctx context.Context, domainName, subName, recordType string) error {
-	if subName == "" {
-		subName = ApexZone
-	}
+	return s.BulkDelete(ctx, domainName, []RRSet{{SubName: subName, Type: recordType}})
+}
 
-	endpoint, err := s.client.createEndpoint("domains", domainName, "rrsets", subName, recordType)
+// BulkDelete deletes RRsets in bulk.
+// https://desec.readthedocs.io/en/latest/dns/rrsets.html#bulk-deletion-of-rrsets
+func (s *RecordsService) BulkDelete(ctx context.Context, domainName string, rrSets []RRSet) error {
+	endpoint, err := s.client.createEndpoint("domains", domainName, "rrsets")
 	if err != nil {
 		return fmt.Errorf("failed to create endpoint: %w", err)
 	}
 
-	req, err := s.client.newRequest(ctx, http.MethodDelete, endpoint, nil)
+	req, err := s.client.newRequest(ctx, http.MethodDelete, endpoint, rrSets)
 	if err != nil {
 		return err
 	}

--- a/records.go
+++ b/records.go
@@ -295,7 +295,13 @@ func (s *RecordsService) BulkDelete(ctx context.Context, domainName string, rrSe
 		return fmt.Errorf("failed to create endpoint: %w", err)
 	}
 
-	req, err := s.client.newRequest(ctx, http.MethodDelete, endpoint, rrSets)
+	deleteRRSets := make([]RRSet, len(rrSets))
+	for i, rrSet := range rrSets {
+		rrSet.Records = []string{}
+		deleteRRSets[i] = rrSet
+	}
+
+	req, err := s.client.newRequest(ctx, http.MethodPut, endpoint, deleteRRSets)
 	if err != nil {
 		return err
 	}
@@ -307,7 +313,7 @@ func (s *RecordsService) BulkDelete(ctx context.Context, domainName string, rrSe
 
 	defer func() { _ = resp.Body.Close() }()
 
-	if resp.StatusCode != http.StatusNoContent {
+	if resp.StatusCode != http.StatusOK {
 		return handleError(resp)
 	}
 

--- a/records.go
+++ b/records.go
@@ -22,7 +22,7 @@ type RRSet struct {
 	Created *time.Time `json:"created,omitempty"`
 }
 
-// RRSetFilter a RRsets filter.
+// RRSetFilter a RRSets filter.
 type RRSetFilter struct {
 	Type    string
 	SubName string
@@ -39,7 +39,7 @@ type RecordsService struct {
 	Domains
 */
 
-// GetAll retrieving all RRsets in a zone.
+// GetAll retrieving all RRSets in a zone.
 // https://desec.readthedocs.io/en/latest/dns/rrsets.html#retrieving-all-rrsets-in-a-zone
 func (s *RecordsService) GetAll(ctx context.Context, domainName string, filter *RRSetFilter) ([]RRSet, error) {
 	endpoint, err := s.client.createEndpoint("domains", domainName, "rrsets")
@@ -281,13 +281,13 @@ func (s *RecordsService) Replace(ctx context.Context, domainName, subName, recor
 	return &updatedRRSet, nil
 }
 
-// Delete deletes a RRset.
+// Delete deletes a RRSet.
 // https://desec.readthedocs.io/en/latest/dns/rrsets.html#deleting-an-rrset
 func (s *RecordsService) Delete(ctx context.Context, domainName, subName, recordType string) error {
 	return s.BulkDelete(ctx, domainName, []RRSet{{SubName: subName, Type: recordType}})
 }
 
-// BulkDelete deletes RRsets in bulk.
+// BulkDelete deletes RRSets in bulk (PATCH).
 // https://desec.readthedocs.io/en/latest/dns/rrsets.html#bulk-deletion-of-rrsets
 func (s *RecordsService) BulkDelete(ctx context.Context, domainName string, rrSets []RRSet) error {
 	endpoint, err := s.client.createEndpoint("domains", domainName, "rrsets")

--- a/records.go
+++ b/records.go
@@ -338,7 +338,7 @@ func (s *RecordsService) BulkUpdate(ctx context.Context, domainName string, rrSe
 	return updatedRRSets, nil
 }
 
-// BulkDelete deletes RRSets in bulk (PATCH).
+// BulkDelete deletes RRSets in bulk (PUT).
 // https://desec.readthedocs.io/en/latest/dns/rrsets.html#bulk-deletion-of-rrsets
 func (s *RecordsService) BulkDelete(ctx context.Context, domainName string, rrSets []RRSet) error {
 	endpoint, err := s.client.createEndpoint("domains", domainName, "rrsets")

--- a/records_test.go
+++ b/records_test.go
@@ -413,7 +413,7 @@ func TestRecordsService_BulkUpdate(t *testing.T) {
 		TTL:     300,
 	}}
 
-	updatedRecord, err := client.Records.BulkUpdate(context.Background(), "example.dedyn.io", rrSets)
+	updatedRecord, err := client.Records.BulkUpdate(context.Background(), FullResourceUpdateMode, "example.dedyn.io", rrSets)
 	require.NoError(t, err)
 
 	expected := []RRSet{{

--- a/records_test.go
+++ b/records_test.go
@@ -76,7 +76,7 @@ func TestRecordsService_Delete(t *testing.T) {
 	client.BaseURL = server.URL
 
 	mux.HandleFunc("/domains/example.dedyn.io/rrsets/", func(rw http.ResponseWriter, req *http.Request) {
-		if req.Method != http.MethodDelete {
+		if req.Method != http.MethodPut {
 			http.Error(rw, "invalid method", http.StatusMethodNotAllowed)
 			return
 		}
@@ -86,12 +86,12 @@ func TestRecordsService_Delete(t *testing.T) {
 			http.Error(rw, "cannot unmarshal request body", http.StatusBadRequest)
 			return
 		}
-		if len(rrSets) != 1 && rrSets[0].SubName != "_acme-challenge" && rrSets[0].Type != "TXT" {
+		if len(rrSets) != 1 && rrSets[0].SubName != "_acme-challenge" && rrSets[0].Type != "TXT" && len(rrSets[0].Records) != 0 {
 			http.Error(rw, "incorrect request body", http.StatusBadRequest)
 			return
 		}
 
-		rw.WriteHeader(http.StatusNoContent)
+		rw.WriteHeader(http.StatusOK)
 	})
 
 	err := client.Records.Delete(context.Background(), "example.dedyn.io", "_acme-challenge", "TXT")

--- a/records_test.go
+++ b/records_test.go
@@ -80,7 +80,7 @@ func TestRecordsService_Delete(t *testing.T) {
 			http.Error(rw, "invalid method", http.StatusMethodNotAllowed)
 			return
 		}
-		defer req.Body.Close()
+		defer func() { _ = req.Body.Close() }()
 		var rrSets []RRSet
 		if err := json.NewDecoder(req.Body).Decode(&rrSets); err != nil {
 			http.Error(rw, "cannot unmarshal request body", http.StatusBadRequest)

--- a/records_test.go
+++ b/records_test.go
@@ -67,58 +67,6 @@ func TestRecordsService_Create(t *testing.T) {
 	assert.Equal(t, expected, newRecord)
 }
 
-func TestRecordsService_BulkCreate(t *testing.T) {
-	mux := http.NewServeMux()
-	server := httptest.NewServer(mux)
-	t.Cleanup(server.Close)
-
-	client := New("token", NewDefaultClientOptions())
-	client.BaseURL = server.URL
-
-	mux.HandleFunc("/domains/example.dedyn.io/rrsets/", func(rw http.ResponseWriter, req *http.Request) {
-		if req.Method != http.MethodPost {
-			http.Error(rw, "invalid method", http.StatusMethodNotAllowed)
-			return
-		}
-
-		rw.WriteHeader(http.StatusCreated)
-		file, err := os.Open("./fixtures/records_create_bulk.json")
-		if err != nil {
-			http.Error(rw, err.Error(), http.StatusInternalServerError)
-			return
-		}
-		defer func() { _ = file.Close() }()
-
-		_, err = io.Copy(rw, file)
-		if err != nil {
-			http.Error(rw, err.Error(), http.StatusInternalServerError)
-			return
-		}
-	})
-
-	rrSets := []RRSet{{
-		Name:    "",
-		SubName: "_acme-challenge",
-		Type:    "TXT",
-		Records: []string{`"txt"`},
-		TTL:     300,
-	}}
-
-	newRecords, err := client.Records.BulkCreate(context.Background(), "example.dedyn.io", rrSets)
-	require.NoError(t, err)
-
-	expected := []RRSet{{
-		Name:    "_acme-challenge.example.dedyn.io.",
-		Domain:  "example.dedyn.io",
-		SubName: "_acme-challenge",
-		Type:    "TXT",
-		Records: []string{`"txt"`},
-		TTL:     300,
-		Created: mustParseTime("2020-05-06T11:46:07.641885Z"),
-	}}
-	assert.Equal(t, expected, newRecords)
-}
-
 func TestRecordsService_Delete(t *testing.T) {
 	mux := http.NewServeMux()
 	server := httptest.NewServer(mux)
@@ -137,47 +85,6 @@ func TestRecordsService_Delete(t *testing.T) {
 	})
 
 	err := client.Records.Delete(context.Background(), "example.dedyn.io", "_acme-challenge", "TXT")
-	require.NoError(t, err)
-}
-
-func TestRecordsService_BulkDelete(t *testing.T) {
-	mux := http.NewServeMux()
-	server := httptest.NewServer(mux)
-	t.Cleanup(server.Close)
-
-	client := New("token", NewDefaultClientOptions())
-	client.BaseURL = server.URL
-
-	mux.HandleFunc("/domains/example.dedyn.io/rrsets/", func(rw http.ResponseWriter, req *http.Request) {
-		if req.Method != http.MethodPut {
-			http.Error(rw, "invalid method", http.StatusMethodNotAllowed)
-			return
-		}
-
-		defer func() { _ = req.Body.Close() }()
-
-		var rrSets []RRSet
-		if err := json.NewDecoder(req.Body).Decode(&rrSets); err != nil {
-			http.Error(rw, "cannot unmarshal request body", http.StatusBadRequest)
-			return
-		}
-		if len(rrSets) != 1 && rrSets[0].SubName != "_acme-challenge" && rrSets[0].Type != "TXT" && len(rrSets[0].Records) != 0 {
-			http.Error(rw, "incorrect request body", http.StatusBadRequest)
-			return
-		}
-
-		rw.WriteHeader(http.StatusOK)
-	})
-
-	rrSets := []RRSet{{
-		Name:    "",
-		SubName: "_acme-challenge",
-		Type:    "TXT",
-		Records: []string{`"txt"`},
-		TTL:     300,
-	}}
-
-	err := client.Records.BulkDelete(context.Background(), "example.dedyn.io", rrSets)
 	require.NoError(t, err)
 }
 
@@ -268,56 +175,6 @@ func TestRecordsService_Update(t *testing.T) {
 		TTL:     300,
 		Created: mustParseTime("2020-05-06T11:46:07.641885Z"),
 	}
-	assert.Equal(t, expected, updatedRecord)
-}
-
-func TestRecordsService_BulkUpdate(t *testing.T) {
-	mux := http.NewServeMux()
-	server := httptest.NewServer(mux)
-	t.Cleanup(server.Close)
-
-	client := New("token", NewDefaultClientOptions())
-	client.BaseURL = server.URL
-
-	mux.HandleFunc("/domains/example.dedyn.io/rrsets/", func(rw http.ResponseWriter, req *http.Request) {
-		if req.Method != http.MethodPut {
-			http.Error(rw, "invalid method", http.StatusMethodNotAllowed)
-			return
-		}
-
-		file, err := os.Open("./fixtures/records_update_bulk.json")
-		if err != nil {
-			http.Error(rw, err.Error(), http.StatusInternalServerError)
-			return
-		}
-		defer func() { _ = file.Close() }()
-
-		_, err = io.Copy(rw, file)
-		if err != nil {
-			http.Error(rw, err.Error(), http.StatusInternalServerError)
-			return
-		}
-	})
-
-	rrSets := []RRSet{{
-		SubName: "_acme-challenge",
-		Type:    "TXT",
-		Records: []string{`"updated"`},
-		TTL:     300,
-	}}
-
-	updatedRecord, err := client.Records.BulkUpdate(context.Background(), "example.dedyn.io", rrSets)
-	require.NoError(t, err)
-
-	expected := []RRSet{{
-		Name:    "_acme-challenge.example.dedyn.io.",
-		Domain:  "example.dedyn.io",
-		SubName: "_acme-challenge",
-		Type:    "TXT",
-		Records: []string{`"updated"`},
-		TTL:     300,
-		Created: mustParseTime("2020-05-06T11:46:07.641885Z"),
-	}}
 	assert.Equal(t, expected, updatedRecord)
 }
 
@@ -426,6 +283,149 @@ func TestRecordsService_GetAll(t *testing.T) {
 		},
 	}
 	assert.Equal(t, expected, records)
+}
+
+func TestRecordsService_BulkCreate(t *testing.T) {
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	client := New("token", NewDefaultClientOptions())
+	client.BaseURL = server.URL
+
+	mux.HandleFunc("/domains/example.dedyn.io/rrsets/", func(rw http.ResponseWriter, req *http.Request) {
+		if req.Method != http.MethodPost {
+			http.Error(rw, "invalid method", http.StatusMethodNotAllowed)
+			return
+		}
+
+		rw.WriteHeader(http.StatusCreated)
+		file, err := os.Open("./fixtures/records_create_bulk.json")
+		if err != nil {
+			http.Error(rw, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		defer func() { _ = file.Close() }()
+
+		_, err = io.Copy(rw, file)
+		if err != nil {
+			http.Error(rw, err.Error(), http.StatusInternalServerError)
+			return
+		}
+	})
+
+	rrSets := []RRSet{{
+		Name:    "",
+		SubName: "_acme-challenge",
+		Type:    "TXT",
+		Records: []string{`"txt"`},
+		TTL:     300,
+	}}
+
+	newRecords, err := client.Records.BulkCreate(context.Background(), "example.dedyn.io", rrSets)
+	require.NoError(t, err)
+
+	expected := []RRSet{{
+		Name:    "_acme-challenge.example.dedyn.io.",
+		Domain:  "example.dedyn.io",
+		SubName: "_acme-challenge",
+		Type:    "TXT",
+		Records: []string{`"txt"`},
+		TTL:     300,
+		Created: mustParseTime("2020-05-06T11:46:07.641885Z"),
+	}}
+	assert.Equal(t, expected, newRecords)
+}
+
+func TestRecordsService_BulkDelete(t *testing.T) {
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	client := New("token", NewDefaultClientOptions())
+	client.BaseURL = server.URL
+
+	mux.HandleFunc("/domains/example.dedyn.io/rrsets/", func(rw http.ResponseWriter, req *http.Request) {
+		if req.Method != http.MethodPut {
+			http.Error(rw, "invalid method", http.StatusMethodNotAllowed)
+			return
+		}
+
+		defer func() { _ = req.Body.Close() }()
+
+		var rrSets []RRSet
+		if err := json.NewDecoder(req.Body).Decode(&rrSets); err != nil {
+			http.Error(rw, "cannot unmarshal request body", http.StatusBadRequest)
+			return
+		}
+		if len(rrSets) != 1 && rrSets[0].SubName != "_acme-challenge" && rrSets[0].Type != "TXT" && len(rrSets[0].Records) != 0 {
+			http.Error(rw, "incorrect request body", http.StatusBadRequest)
+			return
+		}
+
+		rw.WriteHeader(http.StatusOK)
+	})
+
+	rrSets := []RRSet{{
+		Name:    "",
+		SubName: "_acme-challenge",
+		Type:    "TXT",
+		Records: []string{`"txt"`},
+		TTL:     300,
+	}}
+
+	err := client.Records.BulkDelete(context.Background(), "example.dedyn.io", rrSets)
+	require.NoError(t, err)
+}
+
+func TestRecordsService_BulkUpdate(t *testing.T) {
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	client := New("token", NewDefaultClientOptions())
+	client.BaseURL = server.URL
+
+	mux.HandleFunc("/domains/example.dedyn.io/rrsets/", func(rw http.ResponseWriter, req *http.Request) {
+		if req.Method != http.MethodPut {
+			http.Error(rw, "invalid method", http.StatusMethodNotAllowed)
+			return
+		}
+
+		file, err := os.Open("./fixtures/records_update_bulk.json")
+		if err != nil {
+			http.Error(rw, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		defer func() { _ = file.Close() }()
+
+		_, err = io.Copy(rw, file)
+		if err != nil {
+			http.Error(rw, err.Error(), http.StatusInternalServerError)
+			return
+		}
+	})
+
+	rrSets := []RRSet{{
+		SubName: "_acme-challenge",
+		Type:    "TXT",
+		Records: []string{`"updated"`},
+		TTL:     300,
+	}}
+
+	updatedRecord, err := client.Records.BulkUpdate(context.Background(), "example.dedyn.io", rrSets)
+	require.NoError(t, err)
+
+	expected := []RRSet{{
+		Name:    "_acme-challenge.example.dedyn.io.",
+		Domain:  "example.dedyn.io",
+		SubName: "_acme-challenge",
+		Type:    "TXT",
+		Records: []string{`"updated"`},
+		TTL:     300,
+		Created: mustParseTime("2020-05-06T11:46:07.641885Z"),
+	}}
+	assert.Equal(t, expected, updatedRecord)
 }
 
 func mustParseTime(value string) *time.Time {


### PR DESCRIPTION
This adds handling of the bulk endpoints which the deSEC.io API provides. I tried touching as little as possible, reusing as much of the existing code as possible and I also haven't added any tests yet for the bulk endpoints because I wanted to ask whether you'd accept this contribution. If you're okay with this, then I'll polish it and also add tests.

A couple notes on code reuse:
- `Create` now uses the new `BulkCreate` method by passing `ctx, domainName, []RRSet{rrSet}` and the method body of`BulkCreate` only needed a few tweaks and is mostly the original `Create` implementation
- `BulkUpdate` does not reuse code from `Update` because it's a different HTTP verb and operates on multiple records
- `Delete` does use the new `BulkDelete` method but needed a few tweaks, including its tests (we could undo this if you want)

I'm also open to suggestions if you want to do a code review and let me fix mistakes (you did those yourself in #8 😅).