### PR TITLE
feat: add bulk method

### DIFF
--- a/fixtures/records_create_bulk.json
+++ b/fixtures/records_create_bulk.json
@@ -1,0 +1,14 @@
+[
+  {
+    "created": "2020-05-06T11:46:07.641885Z",
+    "domain": "example.dedyn.io",
+    "subname": "_acme-challenge",
+    "name": "_acme-challenge.example.dedyn.io.",
+    "records": [
+      "\"txt\""
+    ],
+    "ttl": 300,
+    "type": "TXT",
+    "touched": "2020-05-06T11:46:07.641885Z"
+  }
+]

--- a/records.go
+++ b/records.go
@@ -288,7 +288,12 @@ func (s *RecordsService) Bulk(ctx context.Context, method, domainName string, rr
 
 	defer func() { _ = resp.Body.Close() }()
 
-	if resp.StatusCode != http.StatusOK {
+	expectedStatusCode := http.StatusOK
+	if method == http.MethodPost {
+		expectedStatusCode = http.StatusCreated
+	}
+
+	if resp.StatusCode != expectedStatusCode {
 		return handleError(resp)
 	}
 

--- a/records.go
+++ b/records.go
@@ -267,3 +267,30 @@ func (s *RecordsService) Delete(ctx context.Context, domainName, subName, record
 
 	return nil
 }
+
+// Bulk to perform bulk operations on RRSets.
+// https://desec.readthedocs.io/en/latest/dns/rrsets.html#bulk-operations
+func (s *RecordsService) Bulk(ctx context.Context, method, domainName string, rrSets []RRSet) error {
+	endpoint, err := s.client.createEndpoint("domains", domainName, "rrsets")
+	if err != nil {
+		return fmt.Errorf("failed to create endpoint: %w", err)
+	}
+
+	req, err := s.client.newRequest(ctx, method, endpoint, rrSets)
+	if err != nil {
+		return err
+	}
+
+	resp, err := s.client.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to call API: %w", err)
+	}
+
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return handleError(resp)
+	}
+
+	return nil
+}

--- a/records.go
+++ b/records.go
@@ -20,6 +20,7 @@ type RRSet struct {
 	Records []string   `json:"records"`
 	TTL     int        `json:"ttl,omitempty"`
 	Created *time.Time `json:"created,omitempty"`
+	Touched *time.Time `json:"touched,omitempty"`
 }
 
 // RRSetFilter a RRsets filter.

--- a/records_test.go
+++ b/records_test.go
@@ -118,6 +118,7 @@ func TestRecordsService_Bulk(t *testing.T) {
 		Records: []string{`"txt"`},
 		TTL:     300,
 		Created: mustParseTime("2020-05-06T11:46:07.641885Z"),
+		Touched: mustParseTime("2020-05-06T11:46:07.641885Z"),
 	}}
 
 	for _, method := range []string{http.MethodPost, http.MethodPut, http.MethodPatch} {


### PR DESCRIPTION
Because the bulk endpoint can handle create, update and delete operations, it is not necessary to have a separate method for each operation, so I implement it differently than in https://github.com/nrdcg/desec/pull/9

Docs: https://desec.readthedocs.io/en/latest/dns/rrsets.html#bulk-operations