### PR TITLE
feat: add additional Get and Update methods

### DIFF
--- a/fixtures/tokens_get.json
+++ b/fixtures/tokens_get.json
@@ -1,0 +1,19 @@
+{
+	"id": "3a6b94b5-d20e-40bd-a7cc-521f5c79fab3",
+	"created": "2018-09-06T09:08:43.762697Z",
+	"last_used": null,
+	"owner": "youremailaddress@example.com",
+	"user_override": null,
+	"max_age": "365 00:00:00",
+	"max_unused_period": null,
+	"name": "my new token",
+	"perm_create_domain": false,
+	"perm_delete_domain": false,
+	"perm_manage_tokens": false,
+	"allowed_subnets": [
+			"0.0.0.0/0",
+			"::/0"
+	],
+	"auto_policy": false,
+	"token": "4pnk7u-NHvrEkFzrhFDRTjGFyX_S"
+}

--- a/fixtures/tokens_getall.json
+++ b/fixtures/tokens_getall.json
@@ -8,5 +8,24 @@
     "created": "2018-09-06T08:53:26.428396Z",
     "id": "76d6e39d-65bc-4ab2-a1b7-6e94eee0a534",
     "name": "sample"
+  },
+  {
+		"id": "3a6b94b5-d20e-40bd-a7cc-521f5c79fab3",
+		"created": "2018-09-06T09:08:43.762697Z",
+		"last_used": null,
+		"owner": "youremailaddress@example.com",
+		"user_override": null,
+		"max_age": "365 00:00:00",
+		"max_unused_period": null,
+		"name": "my new token",
+		"perm_create_domain": false,
+		"perm_delete_domain": false,
+		"perm_manage_tokens": false,
+		"allowed_subnets": [
+				"0.0.0.0/0",
+				"::/0"
+		],
+		"auto_policy": false,
+		"token": "4pnk7u-NHvrEkFzrhFDRTjGFyX_S"
   }
 ]

--- a/fixtures/tokens_policy_get.json
+++ b/fixtures/tokens_policy_get.json
@@ -1,16 +1,7 @@
-[
-	{
-		"id": "7aed3f71-bc81-4f7e-90ae-8f0df0d1c211",
-		"domain": "example.com",
-		"subname": "testing",
-		"type": null,
-		"perm_write": false
-	},
-	{
-		"id": "fa6fdf60-6546-4cee-9168-5d144fe9339c",
-		"domain": "example.com",
-		"subname": "testing",
-		"type": "A",
-		"perm_write": true
-	}
-]
+{
+	"id": "fa6fdf60-6546-4cee-9168-5d144fe9339c",
+	"domain": "example.com",
+	"subname": "testing",
+	"type": "A",
+	"perm_write": true
+}

--- a/fixtures/tokens_policy_get_all.json
+++ b/fixtures/tokens_policy_get_all.json
@@ -1,0 +1,16 @@
+[
+	{
+		"id": "7aed3f71-bc81-4f7e-90ae-8f0df0d1c211",
+		"domain": "example.com",
+		"subname": "testing",
+		"type": null,
+		"perm_write": false
+	},
+	{
+		"id": "fa6fdf60-6546-4cee-9168-5d144fe9339c",
+		"domain": "example.com",
+		"subname": "testing",
+		"type": "A",
+		"perm_write": true
+	}
+]

--- a/fixtures/tokens_policy_update.json
+++ b/fixtures/tokens_policy_update.json
@@ -1,0 +1,7 @@
+{
+	"id": "fa6fdf60-6546-4cee-9168-5d144fe9339c",
+	"domain": "example.com",
+	"subname": "testing",
+	"type": "A",
+	"perm_write": false
+}

--- a/fixtures/tokens_update.json
+++ b/fixtures/tokens_update.json
@@ -1,0 +1,19 @@
+{
+	"id": "3a6b94b5-d20e-40bd-a7cc-521f5c79fab3",
+	"created": "2018-09-06T09:08:43.762697Z",
+	"last_used": null,
+	"owner": "youremailaddress@example.com",
+	"user_override": null,
+	"max_age": "365 00:00:00",
+	"max_unused_period": null,
+	"name": "my new token",
+	"perm_create_domain": true,
+	"perm_delete_domain": false,
+	"perm_manage_tokens": true,
+	"allowed_subnets": [
+			"0.0.0.0/0",
+			"::/0"
+	],
+	"auto_policy": false,
+	"token": "4pnk7u-NHvrEkFzrhFDRTjGFyX_S"
+}

--- a/token_policies.go
+++ b/token_policies.go
@@ -123,6 +123,45 @@ func (s *TokenPoliciesService) Create(ctx context.Context, tokenID string, polic
 	return &tokenPolicy, nil
 }
 
+// Update a token policy
+// https://desec.readthedocs.io/en/latest/auth/tokens.html#token-policy-management
+func (s *TokenPoliciesService) Update(ctx context.Context, tokenID, policyID string, policy TokenPolicy) (*TokenPolicy, error) {
+	endpoint, err := s.client.createEndpoint("auth", "tokens", tokenID, "policies", "rrsets", policyID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create endpoint: %w", err)
+	}
+
+	// Copy values, including only fields that can be modified
+	req, err := s.client.newRequest(ctx, http.MethodPatch, endpoint, TokenPolicy{
+		Domain:          policy.Domain,
+		SubName:         policy.SubName,
+		Type:            policy.Type,
+		WritePermission: policy.WritePermission,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := s.client.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to call API: %w", err)
+	}
+
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, handleError(resp)
+	}
+
+	result := &TokenPolicy{}
+	err = handleResponse(resp, result)
+	if err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}
+
 // Delete deletes a token rrset's policy.
 // https://desec.readthedocs.io/en/latest/auth/tokens.html#token-policy-management
 func (s *TokenPoliciesService) Delete(ctx context.Context, tokenID, policyID string) error {

--- a/token_policies.go
+++ b/token_policies.go
@@ -22,9 +22,42 @@ type TokenPoliciesService struct {
 	client *Client
 }
 
-// Get retrieves token rrset's policies.
+// Get retrieves a specific token rrset policy.
 // https://desec.readthedocs.io/en/latest/auth/tokens.html#token-policy-management
-func (s *TokenPoliciesService) Get(ctx context.Context, tokenID string) ([]TokenPolicy, error) {
+func (s *TokenPoliciesService) Get(ctx context.Context, tokenID, policyID string) (*TokenPolicy, error) {
+	endpoint, err := s.client.createEndpoint("auth", "tokens", tokenID, "policies", "rrsets", policyID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create endpoint: %w", err)
+	}
+
+	req, err := s.client.newRequest(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := s.client.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to call API: %w", err)
+	}
+
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, handleError(resp)
+	}
+
+	policy := &TokenPolicy{}
+	err = handleResponse(resp, policy)
+	if err != nil {
+		return nil, err
+	}
+
+	return policy, nil
+}
+
+// GetAll retrieves all rrset policies for a token.
+// https://desec.readthedocs.io/en/latest/auth/tokens.html#token-policy-management
+func (s *TokenPoliciesService) GetAll(ctx context.Context, tokenID string) ([]TokenPolicy, error) {
 	endpoint, err := s.client.createEndpoint("auth", "tokens", tokenID, "policies", "rrsets")
 	if err != nil {
 		return nil, fmt.Errorf("failed to create endpoint: %w", err)

--- a/token_policies.go
+++ b/token_policies.go
@@ -22,9 +22,42 @@ type TokenPoliciesService struct {
 	client *Client
 }
 
-// Get retrieves a specific token rrset policy.
+// Deprecated: use [TokenPoliciesService.GetAll] instead.
+func (s *TokenPoliciesService) Get(ctx context.Context, tokenID string) ([]TokenPolicy, error) {
+	endpoint, err := s.client.createEndpoint("auth", "tokens", tokenID, "policies", "rrsets")
+	if err != nil {
+		return nil, fmt.Errorf("failed to create endpoint: %w", err)
+	}
+
+	req, err := s.client.newRequest(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := s.client.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to call API: %w", err)
+	}
+
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, handleError(resp)
+	}
+
+	var policies []TokenPolicy
+
+	err = handleResponse(resp, &policies)
+	if err != nil {
+		return nil, err
+	}
+
+	return policies, nil
+}
+
+// GetOne retrieves a specific token rrset policy.
 // https://desec.readthedocs.io/en/latest/auth/tokens.html#token-policy-management
-func (s *TokenPoliciesService) Get(ctx context.Context, tokenID, policyID string) (*TokenPolicy, error) {
+func (s *TokenPoliciesService) GetOne(ctx context.Context, tokenID, policyID string) (*TokenPolicy, error) {
 	endpoint, err := s.client.createEndpoint("auth", "tokens", tokenID, "policies", "rrsets", policyID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create endpoint: %w", err)
@@ -47,6 +80,7 @@ func (s *TokenPoliciesService) Get(ctx context.Context, tokenID, policyID string
 	}
 
 	policy := &TokenPolicy{}
+
 	err = handleResponse(resp, policy)
 	if err != nil {
 		return nil, err
@@ -154,6 +188,7 @@ func (s *TokenPoliciesService) Update(ctx context.Context, tokenID, policyID str
 	}
 
 	result := &TokenPolicy{}
+
 	err = handleResponse(resp, result)
 	if err != nil {
 		return nil, err

--- a/token_policies_test.go
+++ b/token_policies_test.go
@@ -54,6 +54,49 @@ func TestTokenPoliciesService_Get(t *testing.T) {
 	assert.Equal(t, expected, tokens)
 }
 
+func TestTokenPoliciesService_Update(t *testing.T) {
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	client := New("token", NewDefaultClientOptions())
+	client.BaseURL = server.URL
+
+	mux.HandleFunc("/auth/tokens/aaa/policies/rrsets/fa6fdf60-6546-4cee-9168-5d144fe9339c/", func(rw http.ResponseWriter, req *http.Request) {
+		if req.Method != http.MethodPatch {
+			http.Error(rw, "invalid method", http.StatusMethodNotAllowed)
+			return
+		}
+
+		file, err := os.Open("./fixtures/tokens_policy_update.json")
+		if err != nil {
+			http.Error(rw, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		defer func() { _ = file.Close() }()
+
+		_, err = io.Copy(rw, file)
+		if err != nil {
+			http.Error(rw, err.Error(), http.StatusInternalServerError)
+			return
+		}
+	})
+
+	tokens, err := client.TokenPolicies.Update(context.Background(), "aaa", "fa6fdf60-6546-4cee-9168-5d144fe9339c", TokenPolicy{
+		WritePermission: false,
+	})
+	require.NoError(t, err)
+
+	expected := &TokenPolicy{
+		ID:              "fa6fdf60-6546-4cee-9168-5d144fe9339c",
+		Domain:          Pointer("example.com"),
+		SubName:         Pointer("testing"),
+		Type:            Pointer("A"),
+		WritePermission: false,
+	}
+	assert.Equal(t, expected, tokens)
+}
+
 func TestTokenPoliciesService_GetAll(t *testing.T) {
 	mux := http.NewServeMux()
 	server := httptest.NewServer(mux)

--- a/token_policies_test.go
+++ b/token_policies_test.go
@@ -20,6 +20,56 @@ func TestTokenPoliciesService_Get(t *testing.T) {
 	client := New("token", NewDefaultClientOptions())
 	client.BaseURL = server.URL
 
+	mux.HandleFunc("/auth/tokens/aaa/policies/rrsets/", func(rw http.ResponseWriter, req *http.Request) {
+		if req.Method != http.MethodGet {
+			http.Error(rw, "invalid method", http.StatusMethodNotAllowed)
+			return
+		}
+
+		file, err := os.Open("./fixtures/tokens_policy_get_all.json")
+		if err != nil {
+			http.Error(rw, err.Error(), http.StatusInternalServerError)
+			return
+		}
+
+		defer func() { _ = file.Close() }()
+
+		_, err = io.Copy(rw, file)
+		if err != nil {
+			http.Error(rw, err.Error(), http.StatusInternalServerError)
+			return
+		}
+	})
+
+	tokens, err := client.TokenPolicies.Get(context.Background(), "aaa")
+	require.NoError(t, err)
+
+	expected := []TokenPolicy{
+		{
+			ID:              "7aed3f71-bc81-4f7e-90ae-8f0df0d1c211",
+			Domain:          Pointer("example.com"),
+			SubName:         Pointer("testing"),
+			WritePermission: false,
+		},
+		{
+			ID:              "fa6fdf60-6546-4cee-9168-5d144fe9339c",
+			Domain:          Pointer("example.com"),
+			SubName:         Pointer("testing"),
+			Type:            Pointer("A"),
+			WritePermission: true,
+		},
+	}
+	assert.Equal(t, expected, tokens)
+}
+
+func TestTokenPoliciesService_GetOne(t *testing.T) {
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	client := New("token", NewDefaultClientOptions())
+	client.BaseURL = server.URL
+
 	mux.HandleFunc("/auth/tokens/aaa/policies/rrsets/fa6fdf60-6546-4cee-9168-5d144fe9339c/", func(rw http.ResponseWriter, req *http.Request) {
 		if req.Method != http.MethodGet {
 			http.Error(rw, "invalid method", http.StatusMethodNotAllowed)
@@ -41,7 +91,7 @@ func TestTokenPoliciesService_Get(t *testing.T) {
 		}
 	})
 
-	tokens, err := client.TokenPolicies.Get(context.Background(), "aaa", "fa6fdf60-6546-4cee-9168-5d144fe9339c")
+	tokens, err := client.TokenPolicies.GetOne(context.Background(), "aaa", "fa6fdf60-6546-4cee-9168-5d144fe9339c")
 	require.NoError(t, err)
 
 	expected := &TokenPolicy{
@@ -73,6 +123,7 @@ func TestTokenPoliciesService_Update(t *testing.T) {
 			http.Error(rw, err.Error(), http.StatusInternalServerError)
 			return
 		}
+
 		defer func() { _ = file.Close() }()
 
 		_, err = io.Copy(rw, file)
@@ -116,6 +167,7 @@ func TestTokenPoliciesService_GetAll(t *testing.T) {
 			http.Error(rw, err.Error(), http.StatusInternalServerError)
 			return
 		}
+
 		defer func() { _ = file.Close() }()
 
 		_, err = io.Copy(rw, file)

--- a/tokens.go
+++ b/tokens.go
@@ -7,12 +7,46 @@ import (
 	"time"
 )
 
+/* from https://desec.readthedocs.io/en/latest/auth/tokens.html#token-field-reference
+{
+		"id": "3a6b94b5-d20e-40bd-a7cc-521f5c79fab3",
+		"created": "2018-09-06T09:08:43.762697Z",
+		"last_used": null,
+		"owner": "youremailaddress@example.com"",
+		"user_override": null,
+		"max_age": "365 00:00:00",
+		"max_unused_period": null,
+		"name": "my new token",
+		"perm_create_domain": false,
+		"perm_delete_domain": false,
+		"perm_manage_tokens": false,
+		"allowed_subnets": [
+				"0.0.0.0/0",
+				"::/0"
+		],
+		"auto_policy": false,
+		"token": "4pnk7u-NHvrEkFzrhFDRTjGFyX_S"
+}
+*/
+
 // Token a token representation.
 type Token struct {
-	ID      string     `json:"id,omitempty"`
-	Name    string     `json:"name,omitempty"`
-	Value   string     `json:"token,omitempty"`
-	Created *time.Time `json:"created,omitempty"`
+	ID               string     `json:"id,omitempty"`
+	Created          *time.Time `json:"created,omitempty"`
+	LastUsed         *time.Time `json:"last_used,omitempty"`
+	Owner            string     `json:"owner,omitempty"`
+	UserOverride     string     `json:"user_override,omitempty"`
+	Name             string     `json:"name,omitempty"`
+	PermCreateDomain bool       `json:"perm_create_domain"`
+	PermDeleteDomain bool       `json:"perm_delete_domain"`
+	PermManageTokens bool       `json:"perm_manage_tokens"`
+	IsValid          bool       `json:"is_valid,omitempty"`
+	AllowedSubnets   []string   `json:"allowed_subnets,omitempty"`
+	AutoPolicy       bool       `json:"auto_policy"`
+	Value            string     `json:"token,omitempty"`
+	// Not currently implemented
+	// MaxAge           *time.Duration `json:"name,omitempty"`
+	// MaxUnusedPeriod  *time.Duration `json:"name,omitempty"`
 }
 
 // TokensService handles communication with the tokens related methods of the deSEC API.

--- a/tokens.go
+++ b/tokens.go
@@ -92,6 +92,7 @@ func (s *TokensService) GetAll(ctx context.Context) ([]Token, error) {
 
 // Get retrieves a specific token.
 // https://desec.readthedocs.io/en/latest/auth/tokens.html#retrieving-a-specific-token
+// NOTE: This method used to retrieve all policies for a token, that is now done by GetAll
 func (s *TokensService) Get(ctx context.Context, id string) (*Token, error) {
 	endpoint, err := s.client.createEndpoint("auth", "tokens", id)
 	if err != nil {

--- a/tokens.go
+++ b/tokens.go
@@ -7,29 +7,9 @@ import (
 	"time"
 )
 
-/* from https://desec.readthedocs.io/en/latest/auth/tokens.html#token-field-reference
-{
-		"id": "3a6b94b5-d20e-40bd-a7cc-521f5c79fab3",
-		"created": "2018-09-06T09:08:43.762697Z",
-		"last_used": null,
-		"owner": "youremailaddress@example.com"",
-		"user_override": null,
-		"max_age": "365 00:00:00",
-		"max_unused_period": null,
-		"name": "my new token",
-		"perm_create_domain": false,
-		"perm_delete_domain": false,
-		"perm_manage_tokens": false,
-		"allowed_subnets": [
-				"0.0.0.0/0",
-				"::/0"
-		],
-		"auto_policy": false,
-		"token": "4pnk7u-NHvrEkFzrhFDRTjGFyX_S"
-}
-*/
-
 // Token a token representation.
+//
+// https://desec.readthedocs.io/en/latest/auth/tokens.html#token-field-reference
 type Token struct {
 	ID               string     `json:"id,omitempty"`
 	Created          *time.Time `json:"created,omitempty"`
@@ -92,7 +72,7 @@ func (s *TokensService) GetAll(ctx context.Context) ([]Token, error) {
 
 // Get retrieves a specific token.
 // https://desec.readthedocs.io/en/latest/auth/tokens.html#retrieving-a-specific-token
-// NOTE: This method used to retrieve all policies for a token, that is now done by GetAll
+// NOTE: This method used to retrieve all policies for a token, that is now done by GetAll.
 func (s *TokensService) Get(ctx context.Context, id string) (*Token, error) {
 	endpoint, err := s.client.createEndpoint("auth", "tokens", id)
 	if err != nil {
@@ -120,6 +100,7 @@ func (s *TokensService) Get(ctx context.Context, id string) (*Token, error) {
 	}
 
 	token := &Token{}
+
 	err = handleResponse(resp, token)
 	if err != nil {
 		return nil, err
@@ -197,6 +178,7 @@ func (s *TokensService) Update(ctx context.Context, id string, token *Token) (*T
 	}
 
 	result := &Token{}
+
 	err = handleResponse(resp, result)
 	if err != nil {
 		return nil, err

--- a/tokens_test.go
+++ b/tokens_test.go
@@ -117,6 +117,55 @@ func TestTokensService_GetAll(t *testing.T) {
 	assert.Equal(t, expected, tokens)
 }
 
+func TestTokensService_Get(t *testing.T) {
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	client := New("token", NewDefaultClientOptions())
+	client.BaseURL = server.URL
+
+	mux.HandleFunc("/auth/tokens/3a6b94b5-d20e-40bd-a7cc-521f5c79fab3/", func(rw http.ResponseWriter, req *http.Request) {
+		if req.Method != http.MethodGet {
+			http.Error(rw, "invalid method", http.StatusMethodNotAllowed)
+			return
+		}
+
+		file, err := os.Open("./fixtures/tokens_get.json")
+		if err != nil {
+			http.Error(rw, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		defer func() { _ = file.Close() }()
+
+		_, err = io.Copy(rw, file)
+		if err != nil {
+			http.Error(rw, err.Error(), http.StatusInternalServerError)
+			return
+		}
+	})
+
+	token, err := client.Tokens.Get(context.Background(), "3a6b94b5-d20e-40bd-a7cc-521f5c79fab3")
+	require.NoError(t, err)
+
+	expected := &Token{
+		ID:               "3a6b94b5-d20e-40bd-a7cc-521f5c79fab3",
+		Created:          mustParseTime("2018-09-06T09:08:43.762697Z"),
+		Owner:            "youremailaddress@example.com",
+		Name:             "my new token",
+		PermCreateDomain: false,
+		PermDeleteDomain: false,
+		PermManageTokens: false,
+		AllowedSubnets: []string{
+			"0.0.0.0/0",
+			"::/0",
+		},
+		AutoPolicy: false,
+		Value:      "4pnk7u-NHvrEkFzrhFDRTjGFyX_S",
+	}
+	assert.Equal(t, expected, token)
+}
+
 func TestTokensService_Delete(t *testing.T) {
 	mux := http.NewServeMux()
 	server := httptest.NewServer(mux)

--- a/tokens_test.go
+++ b/tokens_test.go
@@ -136,6 +136,7 @@ func TestTokensService_Get(t *testing.T) {
 			http.Error(rw, err.Error(), http.StatusInternalServerError)
 			return
 		}
+
 		defer func() { _ = file.Close() }()
 
 		_, err = io.Copy(rw, file)
@@ -185,6 +186,7 @@ func TestTokensService_Update(t *testing.T) {
 			http.Error(rw, err.Error(), http.StatusInternalServerError)
 			return
 		}
+
 		defer func() { _ = file.Close() }()
 
 		_, err = io.Copy(rw, file)

--- a/tokens_test.go
+++ b/tokens_test.go
@@ -98,6 +98,21 @@ func TestTokensService_GetAll(t *testing.T) {
 			Name:    "sample",
 			Created: mustParseTime("2018-09-06T08:53:26.428396Z"),
 		},
+		{
+			ID:               "3a6b94b5-d20e-40bd-a7cc-521f5c79fab3",
+			Created:          mustParseTime("2018-09-06T09:08:43.762697Z"),
+			Owner:            "youremailaddress@example.com",
+			Name:             "my new token",
+			PermCreateDomain: false,
+			PermDeleteDomain: false,
+			PermManageTokens: false,
+			AllowedSubnets: []string{
+				"0.0.0.0/0",
+				"::/0",
+			},
+			AutoPolicy: false,
+			Value:      "4pnk7u-NHvrEkFzrhFDRTjGFyX_S",
+		},
 	}
 	assert.Equal(t, expected, tokens)
 }


### PR DESCRIPTION
Hey there, first of all thanks for maintaining this repo :)

there were some methods and fields missing which I need for [terraform-provider-desec](https://github.com/Valodim/terraform-provider-desec), so I added them in this PR.

Note in one case I renamed a `Get` method to `GetAll`, implementing a `Get` that is consistent with the other API. The original name was arguably incorrect, and while this is a breaking change it's trivial to fix and I imagine we're not being overly strict on versioning for this repo? If you have an alternative suggestion I'm happy to update.